### PR TITLE
Suggestion: General Name History Channel

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,7 @@ modules = [
     "modules.modmail.mod_mail",
     "modules.modmail.report_msg",
     "modules.art_manager",
+    "modules.general_manager",
     "modules.suggestion_manager",
     "modules.utilities",
     "modules.fun.fun"

--- a/modules/general_manager.py
+++ b/modules/general_manager.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 from datetime import datetime as DT
 
 from modules.base import BaseModule
+from util.embed_maker import *
 
 async def setup(client:commands.Bot, config):
     await client.add_cog(GeneralManager(client))
@@ -16,10 +17,10 @@ class GeneralManager(BaseModule):
         if after == self.d_consts.CHANNEL_GENERAL:
             await self.d_consts.CHANNEL_GENERAL.edit(slowmode_delay=3)
             if after.name != before.name:
-                embed = discord.Embed(title="#general Name Change!", 
-                                      description=f"Name Changed to ***#{after.name}***", 
-                                      timestamp=DT.now(), 
-                                      color=discord.Color.random(seed=int(DT.now().timestamp())))
-                embed.set_footer(text="That Bot vUnknown") #Theres probaly a way to get the version, but i dont wanna figure that out, used modmail as reference.
-                await self.d_consts.CHANNEL_GENERAL_HISTORY.send(embed=embed)
+                await self.d_consts.CHANNEL_GENERAL_HISTORY.send(embed=self.client.embeds.create(
+                embed_type=EmbedType.ACTIVITY_LOG,
+                title = "#general Name Change!",
+                message=f"Name Changed to ***#{after.name}***",
+                color=discord.Colour.random(seed=int(DT.now().timestamp()))
+            ))
 

--- a/modules/general_manager.py
+++ b/modules/general_manager.py
@@ -18,9 +18,8 @@ class GeneralManager(BaseModule):
             await self.d_consts.CHANNEL_GENERAL.edit(slowmode_delay=3)
             if after.name != before.name:
                 await self.d_consts.CHANNEL_GENERAL_HISTORY.send(embed=self.client.embeds.create(
-                embed_type=EmbedType.ACTIVITY_LOG,
-                title = "#general Name Change!",
-                message=f"Name Changed to ***#{after.name}***",
-                color=discord.Colour.random(seed=int(DT.now().timestamp()))
-            ))
+                    embed_type=EmbedType.ACTIVITY_LOG,
+                    title = "#general Name Change!",
+                    message=f"Name Changed to ***#{after.name}***",
+                    color=discord.Colour.random(seed=int(DT.now().timestamp()))))
 

--- a/modules/general_manager.py
+++ b/modules/general_manager.py
@@ -14,8 +14,8 @@ class GeneralManager(BaseModule):
     @commands.Cog.listener()
     async def on_guild_channel_update(self, before: discord.abc.GuildChannel, after: discord.abc.GuildChannel):
         if after == self.d_consts.CHANNEL_GENERAL:
+            await self.d_consts.CHANNEL_GENERAL.edit(slowmode_delay=3)
             if after.name != before.name:
-                await self.d_consts.CHANNEL_GENERAL.edit(slowmode_delay=3)
                 embed = discord.Embed(title="#general Name Change!", 
                                       description=f"Name Changed to ***#{after.name}***", 
                                       timestamp=DT.now(), 

--- a/modules/general_manager.py
+++ b/modules/general_manager.py
@@ -1,0 +1,25 @@
+import discord
+from discord.ext import commands
+from datetime import datetime as DT
+
+from modules.base import BaseModule
+
+async def setup(client:commands.Bot, config):
+    await client.add_cog(GeneralManager(client))
+
+class GeneralManager(BaseModule):
+    def __init__(self, client):
+        self.client = client
+
+    @commands.Cog.listener()
+    async def on_guild_channel_update(self, before: discord.abc.GuildChannel, after: discord.abc.GuildChannel):
+        if after == self.d_consts.CHANNEL_GENERAL:
+            if after.name != before.name:
+                await self.d_consts.CHANNEL_GENERAL.edit(slowmode_delay=3)
+                embed = discord.Embed(title="#general Name Change!", 
+                                      description=f"Name Changed to ***#{after.name}***", 
+                                      timestamp=DT.now(), 
+                                      color=discord.Color.random(seed=int(DT.now().timestamp())))
+                embed.set_footer(text="That Bot vUnknown") #Theres probaly a way to get the version, but i dont wanna figure that out, used modmail as reference.
+                await self.d_consts.CHANNEL_GENERAL_HISTORY.send(embed=embed)
+

--- a/modules/util/discord_const.py
+++ b/modules/util/discord_const.py
@@ -20,7 +20,7 @@ class DiscordConstants(commands.Cog):
         self.client = client
 
         # Initialize all constants. Defined in define_constants on bot ready call
-        self.SERVER = self.CHANNEL_MODMAIL = self.CHANNEL_MISCLOGS = self.CHANNEL_MODLOGS = self.CHANNEL_SUGGESTIONS = self.CHANNEL_YOURART = self.ROLE_STAFF = self.ROLE_OWNER = self.ROLE_ADMIN = self.ROLE_MOD = self.ROLE_MMMISC = self.ROLE_COREBOTS = self.VAR_ALLOWEDMENTIONS_NONE = None
+        self.SERVER = self.CHANNEL_GENERAL = self.CHANNEL_GENERAL_HISTORY = self.CHANNEL_MODMAIL = self.CHANNEL_MISCLOGS = self.CHANNEL_MODLOGS = self.CHANNEL_SUGGESTIONS = self.CHANNEL_YOURART = self.ROLE_STAFF = self.ROLE_OWNER = self.ROLE_ADMIN = self.ROLE_MOD = self.ROLE_MMMISC = self.ROLE_COREBOTS = self.VAR_ALLOWEDMENTIONS_NONE = None
 
     @commands.Cog.listener()
     async def on_ready(self):
@@ -31,6 +31,8 @@ class DiscordConstants(commands.Cog):
         self.SERVER = self.client.get_guild(578356230637223936)
 
         # CHANNELS
+        self.CHANNEL_GENERAL = self.SERBER.get_channel(578356231132020758)
+        self.CHANNEL_GENERAL_HISTORY = self.SERVER.get_channel(0) #Unknown Destination for name log
         self.CHANNEL_MODMAIL = self.SERVER.get_channel(986085007246381147)
         self.CHANNEL_MISCLOGS = self.SERVER.get_channel(608465315755720714)
         self.CHANNEL_MODLOGS = self.SERVER.get_channel(579800016068018186)

--- a/modules/util/embed_maker.py
+++ b/modules/util/embed_maker.py
@@ -15,8 +15,8 @@ class EmbedMaker(): # This probably should not extend BaseModule
     def __init__(self, client:Client):
         self.client = client
 
-    def create(self, embed_type:EmbedType, message:str, title:str="", image_url:str="", error:bool=False):
-        embed = discord.Embed(color=0x69b2ff, title=self.title,description=self.message)
+    def create(self, embed_type:EmbedType, message:str, title:str="", image_url:str="", color:discord.Colour|int=0x69b2ff,error:bool=False):
+        embed = discord.Embed(color=self.color, title=self.title,description=self.message)
 
         if self.image_url is not None:
             embed.set_image(url=self.image_url)

--- a/modules/util/embed_maker.py
+++ b/modules/util/embed_maker.py
@@ -15,7 +15,7 @@ class EmbedMaker(): # This probably should not extend BaseModule
     def __init__(self, client:Client):
         self.client = client
 
-    def create(self, embed_type:EmbedType, message:str, title:str="", image_url:str="", color:discord.Colour|int=0x69b2ff,error:bool=False):
+    def create(self, embed_type:EmbedType, message:str, title:str="", image_url:str="", color:discord.Colour|int=0x69b2ff, error:bool=False):
         embed = discord.Embed(color=self.color, title=self.title,description=self.message)
 
         if self.image_url is not None:


### PR DESCRIPTION
[Discord Link to Original Suggestion](https://ptb.discord.com/channels/578356230637223936/1425334925032296518)

- Adds the ability to track #general's name and log it in a separate channel.
- Reloads the slowmode to #general back to 3 seconds instead of the default 3 each time the channel is edited

Preview of what the log message will be seen as:
<img width="1440" height="427" alt="image" src="https://github.com/user-attachments/assets/3e9c7599-0071-4d39-b490-2e8fcf5de364" />
Embed color is chosen at random